### PR TITLE
Bug: Able to Move Menu Openers While Menu is Open.

### DIFF
--- a/core/src/main/java/net/avicus/atlas/core/item/ItemStackBuilder.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/ItemStackBuilder.java
@@ -119,10 +119,10 @@ public class ItemStackBuilder {
       Arrays.stream(this.tags).forEach(t -> t.set(meta, t.defaultValue));
     }
     if (this.locked) {
-      LockingSharingListener.LOCKED.set(meta, true);
+      ItemUtils.LOCKED.set(meta, true);
     }
     if (this.unShareable) {
-      LockingSharingListener.UN_SHAREABLE.set(meta, true);
+      ItemUtils.UN_SHAREABLE.set(meta, true);
     }
     stack.setItemMeta(meta);
     return stack;

--- a/core/src/main/java/net/avicus/atlas/core/item/ItemUtils.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/ItemUtils.java
@@ -8,6 +8,14 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 public class ItemUtils {
 
+  public static final ItemTag.Boolean LOCKED = new ItemTag.Boolean("locked", false);
+  public static final ItemTag.Boolean UN_SHAREABLE = new ItemTag.Boolean("un-shareable", false);
+
+  public static ItemStack lock(ItemStack stack) {
+    LOCKED.set(stack, true);
+    return stack;
+  }
+
   public static Optional<ItemMeta> tryMeta(ItemStack item) {
     return item.hasItemMeta() ? Optional.of(item.getItemMeta())
         : Optional.empty();
@@ -31,8 +39,8 @@ public class ItemUtils {
       item.setDurability((short) 0);
     }
 
-    LockingSharingListener.UN_SHAREABLE.clear(item);
-    LockingSharingListener.LOCKED.clear(item);
+    UN_SHAREABLE.clear(item);
+    LOCKED.clear(item);
 
     return item;
   }

--- a/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -38,6 +39,16 @@ public class LockingSharingListener implements Listener {
       if (isLocked(event.getWhoClicked().getInventory().getItem(event.getHotbarButton()))) {
         event.setCancelled(true);
       }
+    }
+  }
+
+  @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+  public void onCreativeInventoryAction(InventoryCreativeEvent event) {
+    if (event.getWhoClicked().hasPermission("atlas.spectator.bypass-inventory-lock")) {
+      return;
+    }
+    if (isLocked(event.getWhoClicked().getInventory().getItem(event.getSlot()))) {
+      event.setCancelled(true);
     }
   }
 

--- a/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
@@ -19,6 +19,11 @@ public class LockingSharingListener implements Listener {
   protected static final ItemTag.Boolean LOCKED = new ItemTag.Boolean("locked", false);
   protected static final ItemTag.Boolean UN_SHAREABLE = new ItemTag.Boolean("un-shareable", false);
 
+  public static ItemStack lock(ItemStack stack) {
+    LOCKED.set(stack, true);
+    return stack;
+  }
+
   private boolean isLocked(@Nullable ItemStack item) {
     return item != null && LOCKED.get(item);
   }

--- a/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
@@ -5,8 +5,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -25,36 +25,20 @@ public class LockingSharingListener implements Listener {
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
   public void onInventoryClick(final InventoryClickEvent event) {
-    if (event instanceof InventoryCreativeEvent) {
+    if (isLocked(event.getCurrentItem())) {
+      event.setCancelled(true);
       return;
     }
 
-    // Break out of the switch if the action will move a locked item, otherwise return
-    switch (event.getAction()) {
-      case HOTBAR_SWAP:
-      case HOTBAR_MOVE_AND_READD:
-        // These actions can move up to two stacks. Check the hotbar stack,
-        // and then fall through to check the stack under the cursor.
-        if (isLocked(event.getInventory().getItem(event.getHotbarButton()))) {
-          break;
-        }
-      case PICKUP_ALL:
-      case PICKUP_HALF:
-      case PICKUP_SOME:
-      case PICKUP_ONE:
-      case SWAP_WITH_CURSOR:
-      case MOVE_TO_OTHER_INVENTORY:
-      case DROP_ONE_SLOT:
-      case DROP_ALL_SLOT:
-      case COLLECT_TO_CURSOR:
-        if (isLocked(event.getCurrentItem())) {
-          break;
-        }
-      default:
-        return;
+    // HOTBAR_SWAP/HOTBAR_MOVE_AND_READD can displace a locked hotbar item.
+    // Use getWhoClicked().getInventory() — event.getInventory() is the top view
+    // inventory (e.g. crafting grid when own inventory is open), not the hotbar.
+    InventoryAction action = event.getAction();
+    if (action == InventoryAction.HOTBAR_SWAP || action == InventoryAction.HOTBAR_MOVE_AND_READD) {
+      if (isLocked(event.getWhoClicked().getInventory().getItem(event.getHotbarButton()))) {
+        event.setCancelled(true);
+      }
     }
-
-    event.setCancelled(true);
   }
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)

--- a/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/item/LockingSharingListener.java
@@ -1,6 +1,5 @@
 package net.avicus.atlas.core.item;
 
-import java.util.Iterator;
 import javax.annotation.Nullable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -16,20 +15,12 @@ import org.bukkit.inventory.ItemStack;
  */
 public class LockingSharingListener implements Listener {
 
-  protected static final ItemTag.Boolean LOCKED = new ItemTag.Boolean("locked", false);
-  protected static final ItemTag.Boolean UN_SHAREABLE = new ItemTag.Boolean("un-shareable", false);
-
-  public static ItemStack lock(ItemStack stack) {
-    LOCKED.set(stack, true);
-    return stack;
-  }
-
   private boolean isLocked(@Nullable ItemStack item) {
-    return item != null && LOCKED.get(item);
+    return item != null && ItemUtils.LOCKED.get(item);
   }
 
   private boolean unShareable(@Nullable ItemStack item) {
-    return item != null && (isLocked(item) || UN_SHAREABLE.get(item));
+    return item != null && (isLocked(item) || ItemUtils.UN_SHAREABLE.get(item));
   }
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
@@ -77,10 +68,6 @@ public class LockingSharingListener implements Listener {
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
   public void onDeath(PlayerDeathEvent event) {
-    for (Iterator<ItemStack> iterator = event.getDrops().iterator(); iterator.hasNext(); ) {
-      if (unShareable(iterator.next())) {
-        iterator.remove();
-      }
-    }
+    event.getDrops().removeIf(this::unShareable);
   }
 }

--- a/core/src/main/java/net/avicus/atlas/core/module/groups/SpectatorListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/groups/SpectatorListener.java
@@ -3,7 +3,7 @@ package net.avicus.atlas.core.module.groups;
 import java.util.Collections;
 import java.util.Locale;
 import net.avicus.atlas.core.event.player.PlayerSpawnBeginEvent;
-import net.avicus.atlas.core.item.LockingSharingListener;
+import net.avicus.atlas.core.item.ItemUtils;
 import net.avicus.atlas.core.module.observer.menu.ObserverMenu;
 import net.avicus.atlas.core.util.Messages;
 import net.avicus.compendium.TextStyle;
@@ -39,7 +39,7 @@ public class SpectatorListener implements Listener {
     ));
 
     stack.setItemMeta(meta);
-    return LockingSharingListener.lock(stack);
+    return ItemUtils.lock(stack);
   }
 
   @EventHandler

--- a/core/src/main/java/net/avicus/atlas/core/module/groups/SpectatorListener.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/groups/SpectatorListener.java
@@ -3,6 +3,7 @@ package net.avicus.atlas.core.module.groups;
 import java.util.Collections;
 import java.util.Locale;
 import net.avicus.atlas.core.event.player.PlayerSpawnBeginEvent;
+import net.avicus.atlas.core.item.LockingSharingListener;
 import net.avicus.atlas.core.module.observer.menu.ObserverMenu;
 import net.avicus.atlas.core.util.Messages;
 import net.avicus.compendium.TextStyle;
@@ -38,7 +39,7 @@ public class SpectatorListener implements Listener {
     ));
 
     stack.setItemMeta(meta);
-    return stack;
+    return LockingSharingListener.lock(stack);
   }
 
   @EventHandler

--- a/core/src/main/java/net/avicus/atlas/core/module/groups/menu/GroupMenu.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/groups/menu/GroupMenu.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import net.avicus.atlas.core.item.LockingSharingListener;
+import net.avicus.atlas.core.item.ItemUtils;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.groups.GroupsModule;
 import net.avicus.atlas.core.module.groups.Spectators;
@@ -64,7 +64,7 @@ public class GroupMenu extends InventoryMenu {
     meta.setLore(Collections.singletonList(ChatColor.BLACK + "Team Menu"));
 
     stack.setItemMeta(meta);
-    return LockingSharingListener.lock(stack);
+    return ItemUtils.lock(stack);
   }
 
   public static boolean isMenuOpener(ItemStack stack) {

--- a/core/src/main/java/net/avicus/atlas/core/module/groups/menu/GroupMenu.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/groups/menu/GroupMenu.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import net.avicus.atlas.core.item.LockingSharingListener;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.groups.GroupsModule;
 import net.avicus.atlas.core.module.groups.Spectators;
@@ -63,7 +64,7 @@ public class GroupMenu extends InventoryMenu {
     meta.setLore(Collections.singletonList(ChatColor.BLACK + "Team Menu"));
 
     stack.setItemMeta(meta);
-    return stack;
+    return LockingSharingListener.lock(stack);
   }
 
   public static boolean isMenuOpener(ItemStack stack) {

--- a/core/src/main/java/net/avicus/atlas/core/module/observer/menu/ObserverMenu.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/observer/menu/ObserverMenu.java
@@ -2,6 +2,7 @@ package net.avicus.atlas.core.module.observer.menu;
 
 import java.util.Collections;
 import net.avicus.atlas.core.Atlas;
+import net.avicus.atlas.core.item.LockingSharingListener;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.groups.GroupsModule;
 import net.avicus.atlas.core.module.observer.menu.item.GameModeItem;
@@ -42,7 +43,7 @@ public final class ObserverMenu extends InventoryMenu {
             .render(viewer).toLegacyText());
     meta.setLore(Collections.singletonList(ChatColor.BLACK + "observer-menu"));
     stack.setItemMeta(meta);
-    return stack;
+    return LockingSharingListener.lock(stack);
   }
 
   public static boolean matches(final ItemStack stack) {

--- a/core/src/main/java/net/avicus/atlas/core/module/observer/menu/ObserverMenu.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/observer/menu/ObserverMenu.java
@@ -2,7 +2,7 @@ package net.avicus.atlas.core.module.observer.menu;
 
 import java.util.Collections;
 import net.avicus.atlas.core.Atlas;
-import net.avicus.atlas.core.item.LockingSharingListener;
+import net.avicus.atlas.core.item.ItemUtils;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.groups.GroupsModule;
 import net.avicus.atlas.core.module.observer.menu.item.GameModeItem;
@@ -43,7 +43,7 @@ public final class ObserverMenu extends InventoryMenu {
             .render(viewer).toLegacyText());
     meta.setLore(Collections.singletonList(ChatColor.BLACK + "observer-menu"));
     stack.setItemMeta(meta);
-    return LockingSharingListener.lock(stack);
+    return ItemUtils.lock(stack);
   }
 
   public static boolean matches(final ItemStack stack) {


### PR DESCRIPTION
LockingSharingListener already had full item-locking logic (blocks pickup, swap, drop via NBT tag), but the three menu opener items were never tagged as locked on creation.

Fix: Added LockingSharingListener.lock(ItemStack) utility method, then called it at the end of each item creator:
  - GroupMenu.createMenuOpener()
  - SpectatorListener.createTeleportDevice()
  - ObserverMenu.icon()

Now when these items are given to spectators, they carry the locked NBT tag. The existing click/drop handlers see the tag and cancel any movement attempt.

---

Fixes #9 