### PR TITLE
Fix paper title imports

### DIFF
--- a/core/src/main/java/net/avicus/atlas/core/countdown/StartingCountdown.java
+++ b/core/src/main/java/net/avicus/atlas/core/countdown/StartingCountdown.java
@@ -1,7 +1,7 @@
 package net.avicus.atlas.core.countdown;
 
+import com.destroystokyo.paper.Title;
 import com.google.common.base.Preconditions;
-import java.util.Optional;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.groups.Competitor;
 import net.avicus.atlas.core.module.groups.GroupsModule;
@@ -18,8 +18,9 @@ import net.avicus.compendium.sound.SoundLocation;
 import net.avicus.compendium.sound.SoundType;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.github.paperspigot.Title;
 import org.joda.time.Duration;
+
+import java.util.Optional;
 
 /**
  * Countdown that is used to start a match. This may be triggered from an {@link

--- a/core/src/main/java/net/avicus/atlas/core/fun/Friday13.java
+++ b/core/src/main/java/net/avicus/atlas/core/fun/Friday13.java
@@ -1,6 +1,6 @@
 package net.avicus.atlas.core.fun;
 
-import java.util.Random;
+import com.destroystokyo.paper.Title;
 import net.avicus.atlas.core.Atlas;
 import net.avicus.atlas.core.util.AtlasTask;
 import net.md_5.bungee.api.ChatColor;
@@ -12,7 +12,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-import org.github.paperspigot.Title;
+
+import java.util.Random;
 
 public class Friday13 implements Listener {
 

--- a/core/src/main/java/net/avicus/atlas/core/module/executors/types/SendMessageExecutor.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/executors/types/SendMessageExecutor.java
@@ -1,6 +1,6 @@
 package net.avicus.atlas.core.module.executors.types;
 
-import java.util.UUID;
+import com.destroystokyo.paper.Title;
 import lombok.ToString;
 import net.avicus.atlas.core.documentation.FeatureDocumentation;
 import net.avicus.atlas.core.documentation.InfoTable;
@@ -20,7 +20,8 @@ import net.avicus.atlas.core.util.xml.XmlException;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
-import org.github.paperspigot.Title;
+
+import java.util.UUID;
 
 /**
  * An executor that sends a message to a player. Can send titles, subtitles, and chat messages

--- a/core/src/main/java/net/avicus/atlas/core/module/results/ResultsModule.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/results/ResultsModule.java
@@ -1,13 +1,7 @@
 package net.avicus.atlas.core.module.results;
 
+import com.destroystokyo.paper.Title;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.ToString;
 import net.avicus.atlas.core.countdown.MatchEndCountdown;
@@ -51,7 +45,14 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.github.paperspigot.Title;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @ToString(exclude = "match")
 public class ResultsModule extends BridgeableModule<ModuleBridge<ResultsModule>> implements Module {

--- a/core/src/main/java/net/avicus/atlas/core/module/results/scenario/TieScenario.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/results/scenario/TieScenario.java
@@ -1,5 +1,6 @@
 package net.avicus.atlas.core.module.results.scenario;
 
+import com.destroystokyo.paper.Title;
 import lombok.ToString;
 import net.avicus.atlas.core.match.Match;
 import net.avicus.atlas.core.module.checks.Check;
@@ -14,7 +15,6 @@ import net.avicus.compendium.sound.SoundType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.github.paperspigot.Title;
 
 /**
  * Internal scenario to handle when check passes but no winner can be clearly decided.

--- a/core/src/main/java/net/avicus/atlas/core/module/spawns/RespawnTask.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/spawns/RespawnTask.java
@@ -1,7 +1,6 @@
 package net.avicus.atlas.core.module.spawns;
 
-import java.util.Locale;
-import java.util.Optional;
+import com.destroystokyo.paper.Title;
 import lombok.Getter;
 import lombok.Setter;
 import net.avicus.atlas.core.Atlas;
@@ -29,10 +28,12 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-import org.github.paperspigot.Title;
 import org.joda.time.Instant;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import tc.oc.tracker.event.PlayerDamageEvent;
+
+import java.util.Locale;
+import java.util.Optional;
 
 public class RespawnTask extends AtlasTask implements Listener {
 

--- a/core/src/main/java/net/avicus/atlas/core/module/stats/StatsModule.java
+++ b/core/src/main/java/net/avicus/atlas/core/module/stats/StatsModule.java
@@ -1,15 +1,7 @@
 package net.avicus.atlas.core.module.stats;
 
+import com.destroystokyo.paper.Title;
 import com.google.common.collect.Maps;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.ToString;
 import net.avicus.atlas.core.channel.staff.StaffChannels;
@@ -40,7 +32,16 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.github.paperspigot.Title;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 @ToString(exclude = "match")
 public class StatsModule extends BridgeableModule<ModuleBridge<StatsModule>> implements Module {

--- a/core/src/main/java/net/avicus/atlas/core/util/LocalizedXmlTitle.java
+++ b/core/src/main/java/net/avicus/atlas/core/util/LocalizedXmlTitle.java
@@ -1,9 +1,8 @@
 package net.avicus.atlas.core.util;
 
-import java.util.Locale;
+import com.destroystokyo.paper.Title;
 import net.avicus.atlas.core.module.locales.LocalizedXmlString;
 import org.bukkit.entity.Player;
-import org.github.paperspigot.Title;
 
 public class LocalizedXmlTitle {
 


### PR DESCRIPTION
Some patch changes to sportpaper relocated paper-specific code to `com.destroystokyo` namespace. This broke all title imports.

--------------

Breaking change:

"Move Paper-specific code to com.destroystokyo namespace"; this makes building against both legacy and modern by way of [JarIntersector](https://github.com/Pablete1234/JarIntersector) simpler as there are more shared events between modern and legacy than we are able to use without a namespace change.

Reference: https://github.com/Electroid/SportPaper/pull/157